### PR TITLE
Fix imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 /Manifest.toml
 /docs/build/
 /docs/Manifest.toml
+
+# IDE and Editors
+.vscode/
+.idea/
+
+# MACOS Files and Property file
+.DS_Store

--- a/src/common.jl
+++ b/src/common.jl
@@ -37,7 +37,8 @@ pattern_length(pf) = length(pattern(pf))
     length(pf<:PatternFold)
 Return the length of `pf` if unfolded.
 """
-length(pf) = pattern_length(pf) * folds(pf)
+
+Base.length(pf::PatternFold) = pattern_length(pf) * folds(pf)
 
 """
     rand(pf<:PatternFold)


### PR DESCRIPTION
TheCoolMoriarty has suggested to rename the `length(pf)` to `Base.length(pf::PatternFold)` on line 41.
Since this is a minor fix, I also included
```
# IDE and Editors
.vscode/
.idea/

# MACOS Files and Property file
.DS_Store
```
inside `.gitignore` because these files or directories can be accidentally added on push :D